### PR TITLE
Add install-dir to avoid addon override

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here's the easiest:
 
 2. Clone the magerun-addons repository in there
 
-        cd ~/.n98-magerun/modules/ && git clone git@github.com:tschifftner/magerun-addons.git
+        cd ~/.n98-magerun/modules/ && git clone git@github.com:tschifftner/magerun-addons.git ~/.n98-magerun/modules/tschifftner-magerun
 
 3. It should be installed. To see that it was installed, check to see if one of the new commands is in there, like `order:setstatus:complete`.
 


### PR DESCRIPTION
Add install-dir to install instructions to avoid override of other magerun-addons